### PR TITLE
Added stripped down live broadcast demo

### DIFF
--- a/Live-Broadcast/README.md
+++ b/Live-Broadcast/README.md
@@ -1,0 +1,318 @@
+# Vonage Video API Broadcast Sample App for JavaScript
+
+<img src="https://assets.tokbox.com/img/vonage/Vonage_VideoAPI_black.svg" height="48px" alt="Tokbox is now known as Vonage" />
+
+This document describes how to use the Video API Broadcast Sample App for JavaScript. Through
+the exploration of this sample application, you will learn best practices for setting up and
+managing hosts, guests, and viewers in a web-based broadcasting application.
+
+In the Video API Broadcast Sample App, the host is the individual who controls and publishes
+the broadcast. The sample app supports up to 3 guests who can publish in the broadcast.
+
+The sample app also supports the following recommended numbers of viewers, based on the
+number of publishers in the broadcast:
+
+- 1 host, 3 guests: 11000 viewers
+- 1 host, 2 guests: 13000 viewers
+- 1 host, 1 guest: 15000 viewers
+
+The Vonage Video API live streaming feature lets you broadcast an Video API session to an HTTP live
+streaming (HLS) stream. More clients can simultaneously view this stream than can view
+a live interactive Video API session. Also, clients that do not support WebRTC
+can view the HLS stream. HLS playback is not supported in all browsers. However, there are a
+number of plugins, such as [Flowplayer](https://flowplayer.org/), that provide
+cross-browser support (using Flash Player in browsers that do not provide direct HLS support).
+
+The DVR feature provides a two-hour window for playing back broadcast content. While the broadcast is in progress, you can play back (and rewind to) any point in the broadcast up to two hours prior to the current time. The DVR recording is unavailable two hours after the broadcast is stopped.
+
+**NOTE**: The viewer limits do not apply to HLS, since all publishing streams are transcoded
+to a single HLS stream that can be accessed from an HLS player. The expected latency for HLS
+is 10-15 seconds and for low latency HLS is shorter. The host can select different options to start the broadcast (Full HD, Low latency and DVR).
+The viewers can move back and forth from the HLS viewer view to the WebRTC view.
+
+Instead of the regular Broadcast view, the Host can decide to compose a custom view with all the published streams in the session. This is done through the [Experience Composer API](https://www.tokbox.com/developer/guides/experience-composer/) which allows publishing a custom application view with your own layout as a stream into the session. The host has additional controls to apply a custom background to the composed view and round the corners of the video tiles. If a background option is selected, an Experience Composer stream will be published into the session, otherwise a regular broadcast will be composed.
+
+**NOTE**: The price for a Experience Composer stream differs from a regular stream. Check [this article](https://video-api.support.vonage.com/hc/en-us/articles/6714156901780-Experience-Composer-Activation-and-Pricing) for further pricing information
+
+You can configure and run this sample app within just a few minutes!
+
+This guide has the following sections:
+
+- [Prerequisites](#prerequisites): A checklist of everything you need to get started.
+- [Quick start](#quick-start): A step-by-step tutorial to help you quickly run the sample app.
+- [Exploring the code](#exploring-the-code): This describes the sample app code design, which
+  uses recommended best practices to implement the Video API Broadcast app features.
+
+## Prerequisites
+
+To be prepared to develop your Video API Broadcast app:
+
+1. Review the [OpenTok.js](https://tokbox.com/developer/sdks/js/) requirements.
+2. Your app will need an Video API **API Key** and **API Secret**, which you can get from
+   the [OpenTok Developer Dashboard](https://dashboard.tokbox.com/). Set the API Key and
+   API Secret along with your **production_url** in [config.json](./config.json).
+3. Enable Experience Composer in the [account Portal](https://tokbox.com/account)
+   To run the Video API Broadcast Sample App, run the following commands:
+
+```bash
+npm i
+npm start
+```
+
+_**NOTE**: The Video API Developer Dashboard allows you to quickly run this sample program. For production deployment, you must generate the **Session ID** and **Token** values using one of the [Video API Server SDKs](https://tokbox.com/developer/sdks/server/)._
+
+_**IMPORTANT:** In order to deploy an Video API Broadcast app, your web domain must use HTTPS._
+
+## Quick start
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+The web page that loads the sample app for JavaScript must be served over HTTP/HTTPS. Browser
+security limitations prevent you from publishing video using a `file://` path, as discussed in
+the OpenTok.js [Release Notes](https://www.tokbox.com/developer/sdks/js/release-notes.html#knownIssues). To
+support clients running [Chrome 47 or later](https://groups.google.com/forum/#!topic/discuss-webrtc/sq5CVmY69sc),
+HTTPS is required. A web server such as [MAMP](https://www.mamp.info/) or
+[XAMPP](https://www.apachefriends.org/index.html) will work, or you can use a cloud service such
+as [Heroku](https://www.heroku.com/) to host the application.
+
+### Starting a broadcast
+
+From the host view, press the `Start Broadcast` button and optionally provide the RTMP Server URL and Stream Name. You can configure different parametes for the broadcast (HLS Low Latency, DVR and Full HD)
+
+- Note: DVR functionality and Low Latency are incompatible
+
+## Exploring the code
+
+This section describes how the sample app code design uses recommended best practices to deploy the broadcast features.
+
+For detail about the APIs used to develop this sample, see
+the [OpenTok.js Reference](https://tokbox.com/developer/sdks/js/reference/).
+
+- [Web page design](#web-page-design)
+- [Server](#server)
+- [Guest](#guest)
+- [Viewer](#viewer)
+- [Host](#host)
+- [HLS Viewer](#hls-viewer)
+- [Experience Composer](#experience-composer)
+
+_**NOTE:** The sample app contains logic used for logging. This is used to submit anonymous usage data for internal Vonage purposes only. We request that you do not modify or remove any logging code in your use of this sample application._
+
+### Web page design
+
+While Vonage hosts [OpenTok.js](https://tokbox.com/developer/sdks/js/), you must host the
+sample app yourself. This allows you to customize the app as desired.
+
+- **[server.js](./server.js)**: The server configures the routes for the host, guests, and viewers.
+
+- **[opentok-api.js](./services/opentok-api.js)**: Configures the **Session ID**, **Token**,
+  and **API Key**, creates the Video API session, and generates tokens for hosts, guests, and
+  viewers. Set the API Key and API Secret in [config.json](./config.json).
+
+- **[host.js](./public/js/host.js)**: The host is the individual who controls and publishes
+  the broadcast, but does not control audio or video for guests or viewers. The host uses the
+  Video API [Signaling API](https://www.tokbox.com/developer/guides/signaling/js/) to send the
+  signals to all clients in the session.
+
+- **[guest.js](./public/js/guest.js)**: Guests can publish in the broadcast. They can control
+  their own audio and video. The sample app does not include the ability for the host to
+  control whether guests are broadcasting, though the host does have a moderator token that
+  can be used for that purpose.
+
+- **[viewer.js](./public/js/viewer.js)**: Viewers can view the live WebRTC stream and switch to the Guest and HLS views.
+
+- **[hls-viewer.js](./public/js/hls-viewer.js)**: HLS Viewers can only view the broadcast and switch to the viewer view.
+
+- **[hls-viewer.js](./public/js/hls-viewer.js)**: HLS Viewers can only view the broadcast.
+
+- **[ec.js](./public/js/hls-viewer.js)**: This page defines the code that the Experience Composer instance needs to execute.
+
+- **[CSS files](./public/css)**: Defines the client UI style.
+
+### Server
+
+The methods in [server.js](./server.js) include the host, guest, and viewer routes, as well
+as the broadcast start and end routes. Each of the host, guest, and viewer routes retrieves
+the credentials and creates the token for each user type (moderator, publisher, subscriber)
+defined in [opentok-api.js](./services/opentok-api.js):
+
+```javascript
+const tokenOptions = (userType) => {
+  const role = {
+    host: "moderator",
+    guest: "publisher",
+    viewer: "subscriber",
+  }[userType];
+
+  return { role };
+};
+```
+
+The credentials are embedded in an EJS template as JSON. For example, the following host
+route is configured in server.js:
+
+```javascript
+app.get("/host", async (req, res) => {
+  const roomName = req.query.room;
+  try {
+    const credentials = await generateCredentials("host", roomName);
+    res.render("pages/host", {
+      credentials: JSON.stringify(credentials),
+    });
+  } catch (e) {
+    res.status(500).send(error);
+  }
+});
+```
+
+The credentials are then retrieved in [host.js](./public/js/host.js) and used to connect to the host to the session:
+
+```javascript
+  var getCredentials = function () {
+    var el = document.getElementById('credentials');
+    var credentials = JSON.parse(el.getAttribute('data'));
+    el.remove();
+    return credentials;
+  };
+
+  . . .
+
+  var init = function () {
+
+    . . .
+
+    var credentials = getCredentials();
+    var session = OT.initSession(credentials.apiKey, credentials.sessionId);
+    var publisher = initPublisher();
+
+    session.connect(credentials.token, function (error) {
+
+      . . .
+
+    });
+  };
+
+
+```
+
+When the web page is loaded, those credentials are retrieved from the HTML and are used to initialize the session.
+
+The logic needed to start and stop the Experience Composer stream is defined in [opentok-api.js](./services/opentok-api.js) (`createRender` and `deleteRender` respectively). At the time of updating this sample application, the nodeJS SDK does not have support for Experience Composer, so the [REST API](https://www.dev.tokbox.com/developer/rest/#starting_experience_composer) will be used. The `createRender` function creates an Experience Composer instance that will navigate to **[ec.js](./public/js/hls-viewer.js)** and publish a new stream named `EC` into the session.
+
+### Guest
+
+The functions in [guest.js](./public/js/guest.js) retrieve the credentials from the HTML,
+subscribe to the host stream and other guest streams, and publish audio and video to the session.
+
+### HLS viewer
+
+The functions in [viewer.js](./public/js/hls-viewer.js) check whether the broadcast is active or not. The HLS viewer can also move to the Viewer view (WebRTC session). Your application is responsible to let the HLS viewers when the HLS stream has started, this could be via WSS or any other way. For simplicity, this sample app has a button that checks the server for the broadcast URL.
+
+**NOTE**: The price for an Experience Composer stream differs from a regular stream. Check [this article](https://video-api.support.vonage.com/hc/en-us/articles/6714156901780-Experience-Composer-Activation-and-Pricing) for further pricing information.
+
+### Experience Composer
+
+The code in [ec.js](./public/js/ec.js) will connect the Experience Composer instance to the session, subscribe to all streams but itself and the screen share stream from the Host and customise the appearance of the page. The result of the interaction with this code, that is, what is visible on this page, will be published as a new stream into the session (see logic on `opentok-api.js`).
+
+### Viewer
+
+The functions in [viewer.js](./public/js/viewer.js) retrieve the credentials from the HTML,
+connect to the session and subscribe after receiving a signal from the host indicating the broadcast has started, and monitor broadcast status. Once the broadcast begins, the viewer can see the host and guests. Each viewer uses the Video API [Signaling API](https://www.tokbox.com/developer/guides/signaling/js/) to receive the signals sent in the broadcast. The viewer can also move to the HLS viewer view and become a Guest to publish audio and video.
+
+### Host
+
+The methods in [host.js](./public/js/host.js) retrieve the credentials from the HTML, set the
+state of the broadcast and update the UI, control the broadcast stream, subscribe to the guest
+streams, create the URL for viewers to watch the broadcast, and signal broadcast status. The
+host UI includes an input field to add an [RTMP stream](https://tokbox.com/developer/beta/rtmp-broadcast/),
+a button to start and end the broadcast, as well as a control to get a sharable link that
+can be distributed to all potential viewers to watch the CDN stream. The host makes calls to
+the server, which calls the Video API API to start and end the broadcast. Once the broadcast ends,
+the client player will recognize an error event and display a message that the broadcast is over.
+For more information, see [Initialize, Connect, and Publish to a Session](https://tokbox.com/developer/concepts/connect-and-publish/).
+
+The following method in host.js sets up the publisher session for the host, configures a
+custom UI with controls for the publisher role associated with the host, and sets up event
+listeners for the broadcast button.
+
+```javascript
+var publishAndSubscribe = function (session, publisher) {
+  session.publish(publisher);
+  addPublisherControls(publisher);
+  setEventListeners(session, publisher);
+};
+```
+
+When the broadcast button is clicked, the `startBroadcast()` method is invoked and submits
+a request to the server endpoint to begin the broadcast. The server endpoint relays the
+session ID to the [Video API HLS Broadcast REST](https://tokbox.com/developer/rest/#start_broadcast)
+`/broadcast/start` endpoint, which returns broadcast data to the host. The broadcast data
+includes the broadcast URL in its JSON-encoded HTTP response:
+
+```javascript
+  var startBroadcast = function (session) {
+
+    . . .
+
+    http.post('/broadcast/start', { sessionId: session.sessionId })
+      .then(function (broadcastData) {
+
+        updateStatus(session, 'active');
+
+        . . .
+
+      }
+  };
+```
+
+The `startBroadcast()` method subsequently calls the `updateStatus()` method with the broadcast
+status. The `updateStatus()` method uses the [Video API Signaling API](https://www.tokbox.com/developer/guides/signaling/js/)
+to notify the live viewers who are subscribed to the session that the broadcast has started:
+
+```javascript
+  var updateStatus = function (session, status) {
+
+    . . .
+
+    signal(session, broadcast.status);
+  };
+```
+
+If a guest joins the HLS view after the broadcast has started, it will send a signal to the host to retrieve the current status of the broadcast. If the broadcast is active, the host will send them the URL so they can play the HLS feed.
+
+When the broadcast is over, the `endBroadcast()` method in host.js submits a request to the server,
+which invokes the [Video API Broadcast API](https://tokbox.com/developer/rest/#stop_broadcast) `/broadcast/stop`
+endpoint, which terminates the CDN stream. This is a recommended best practice, as the default
+is that broadcasts remain active until a 120-minute timeout period has completed.
+
+## Screenshots
+
+### Host View
+
+![Host-view](https://github.com/nexmo-se/broadcast-sample-app/blob/main/public/images/host.jpg?raw=true)
+
+### WebRTC Viewer
+
+![Host-view](https://github.com/nexmo-se/broadcast-sample-app/blob/main/public/images/webrtc.jpg?raw=true)
+
+### HLS Viewer
+
+![Host-view](https://github.com/nexmo-se/broadcast-sample-app/blob/main/public/images/hls.jpg?raw=true)
+
+## Development and Contributing
+
+Interested in contributing? We :heart: pull requests! See the [Contribution](CONTRIBUTING.md) guidelines.
+
+## Getting Help
+
+We love to hear from you so if you have questions, comments or find a bug in the project, let us
+know! You can either:
+
+- Open an issue on this repository
+- See <https://support.tokbox.com/> for support options
+- Tweet at us! We're [@VonageDev](https://twitter.com/VonageDev) on Twitter
+- Or [join the Vonage Developer Community Slack](https://developer.nexmo.com/community/slack)
+
+## Further Reading
+
+- Check out the Developer Documentation at <https://tokbox.com/developer/>

--- a/Live-Broadcast/README.md
+++ b/Live-Broadcast/README.md
@@ -2,37 +2,26 @@
 
 <img src="https://assets.tokbox.com/img/vonage/Vonage_VideoAPI_black.svg" height="48px" alt="Tokbox is now known as Vonage" />
 
-This document describes how to use the Video API Broadcast Sample App for JavaScript. Through
-the exploration of this sample application, you will learn best practices for setting up and
-managing hosts, guests, and viewers in a web-based broadcasting application.
+This document describes how to use the Video API Broadcast Sample App for JavaScript. This
+demo will show you a basic 1:many broadcast application using both WebRTC and HLS. 
 
 In the Video API Broadcast Sample App, the host is the individual who controls and publishes
-the broadcast. The sample app supports up to 3 guests who can publish in the broadcast.
-
-The sample app also supports the following recommended numbers of viewers, based on the
-number of publishers in the broadcast:
-
-- 1 host, 3 guests: 11000 viewers
-- 1 host, 2 guests: 13000 viewers
-- 1 host, 1 guest: 15000 viewers
+the broadcast.
 
 The Vonage Video API live streaming feature lets you broadcast an Video API session to an HTTP live
 streaming (HLS) stream. More clients can simultaneously view this stream than can view
 a live interactive Video API session. Also, clients that do not support WebRTC
 can view the HLS stream. HLS playback is not supported in all browsers. However, there are a
 number of plugins, such as [Flowplayer](https://flowplayer.org/), that provide
-cross-browser support (using Flash Player in browsers that do not provide direct HLS support).
+cross-browser support (using Flash Player in browsers that do not provide direct HLS support). The demo
+uses [Hls.js](https://www.npmjs.com/package/hls.js/v/canary).
 
 The DVR feature provides a two-hour window for playing back broadcast content. While the broadcast is in progress, you can play back (and rewind to) any point in the broadcast up to two hours prior to the current time. The DVR recording is unavailable two hours after the broadcast is stopped.
 
 **NOTE**: The viewer limits do not apply to HLS, since all publishing streams are transcoded
 to a single HLS stream that can be accessed from an HLS player. The expected latency for HLS
-is 10-15 seconds and for low latency HLS is shorter. The host can select different options to start the broadcast (Full HD, Low latency and DVR).
+is 10-15 seconds and for low latency HLS is shorter. The host can select different options to start the broadcast (Low latency and DVR).
 The viewers can move back and forth from the HLS viewer view to the WebRTC view.
-
-Instead of the regular Broadcast view, the Host can decide to compose a custom view with all the published streams in the session. This is done through the [Experience Composer API](https://www.tokbox.com/developer/guides/experience-composer/) which allows publishing a custom application view with your own layout as a stream into the session. The host has additional controls to apply a custom background to the composed view and round the corners of the video tiles. If a background option is selected, an Experience Composer stream will be published into the session, otherwise a regular broadcast will be composed.
-
-**NOTE**: The price for a Experience Composer stream differs from a regular stream. Check [this article](https://video-api.support.vonage.com/hc/en-us/articles/6714156901780-Experience-Composer-Activation-and-Pricing) for further pricing information
 
 You can configure and run this sample app within just a few minutes!
 
@@ -47,37 +36,44 @@ This guide has the following sections:
 
 To be prepared to develop your Video API Broadcast app:
 
-1. Review the [OpenTok.js](https://tokbox.com/developer/sdks/js/) requirements.
-2. Your app will need an Video API **API Key** and **API Secret**, which you can get from
-   the [OpenTok Developer Dashboard](https://dashboard.tokbox.com/). Set the API Key and
-   API Secret along with your **production_url** in [config.json](./config.json).
-3. Enable Experience Composer in the [account Portal](https://tokbox.com/account)
-   To run the Video API Broadcast Sample App, run the following commands:
+1. Review the [Vonage Video Video Client SDK](https://developer.vonage.com/en/video/client-sdks/web) requirements.
+2. This application requires a Sample Server with broadcast capabilities. We suggest our [Sample Video Node Learning Server](https://github.com/Vonage-Community/sample-video-node-learning_server/).
 
 ```bash
 npm i
 npm start
 ```
 
-_**NOTE**: The Video API Developer Dashboard allows you to quickly run this sample program. For production deployment, you must generate the **Session ID** and **Token** values using one of the [Video API Server SDKs](https://tokbox.com/developer/sdks/server/)._
-
-_**IMPORTANT:** In order to deploy an Video API Broadcast app, your web domain must use HTTPS._
+_**IMPORTANT:** If you deploy this demo, the hosting service MUST use HTTPS to serve your demo.
 
 ## Quick start
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/vonage-community/video-api-web-samples/tree/main/Live-Broadcast)
 
 The web page that loads the sample app for JavaScript must be served over HTTP/HTTPS. Browser
-security limitations prevent you from publishing video using a `file://` path, as discussed in
-the OpenTok.js [Release Notes](https://www.tokbox.com/developer/sdks/js/release-notes.html#knownIssues). To
+security limitations prevent you from publishing video using a `file://` path. To
 support clients running [Chrome 47 or later](https://groups.google.com/forum/#!topic/discuss-webrtc/sq5CVmY69sc),
 HTTPS is required. A web server such as [MAMP](https://www.mamp.info/) or
 [XAMPP](https://www.apachefriends.org/index.html) will work, or you can use a cloud service such
-as [Heroku](https://www.heroku.com/) to host the application.
+as [StackBlitz](https://www.heroku.com/) to host the application.
+
+You can also run the front-end locally by using:
+
+```bash
+npm i
+npm start
+```
+
+This will start a local instance of `sirv`, which will serve the application on `https://localhost:8080`. 
+
+You will also need a server that can interact with our API. You can build your own, or deploy our [Sample Video Node Learning Server](https://github.com/Vonage-Community/sample-video-node-learning_server/).
+Both the sample server and this demo can be run locally, or you can deploy the sample server to a service
+like Railway, and point this demo at the public URL of the Railway application. For more info, please check
+out the [sample server's README](https://github.com/Vonage-Community/sample-video-node-learning_server/).
 
 ### Starting a broadcast
 
-From the host view, press the `Start Broadcast` button and optionally provide the RTMP Server URL and Stream Name. You can configure different parametes for the broadcast (HLS Low Latency, DVR and Full HD)
+From the host view, press the `Start Broadcast` button. You can configure different parametes for the broadcast (HLS Low Latency, DVR )
 
 - Note: DVR functionality and Low Latency are incompatible
 
@@ -86,7 +82,7 @@ From the host view, press the `Start Broadcast` button and optionally provide th
 This section describes how the sample app code design uses recommended best practices to deploy the broadcast features.
 
 For detail about the APIs used to develop this sample, see
-the [OpenTok.js Reference](https://tokbox.com/developer/sdks/js/reference/).
+the [Vonage Video Client SDK Reference](https://developer.vonage.com/en/video/client-sdks/web).
 
 - [Web page design](#web-page-design)
 - [Server](#server)
@@ -96,212 +92,105 @@ the [OpenTok.js Reference](https://tokbox.com/developer/sdks/js/reference/).
 - [HLS Viewer](#hls-viewer)
 - [Experience Composer](#experience-composer)
 
-_**NOTE:** The sample app contains logic used for logging. This is used to submit anonymous usage data for internal Vonage purposes only. We request that you do not modify or remove any logging code in your use of this sample application._
-
 ### Web page design
 
-While Vonage hosts [OpenTok.js](https://tokbox.com/developer/sdks/js/), you must host the
+While Vonage hosts [Vonage Video Client SDK](https://developer.vonage.com/en/video/client-sdks/web), you must host the
 sample app yourself. This allows you to customize the app as desired.
 
-- **[server.js](./server.js)**: The server configures the routes for the host, guests, and viewers.
+- **[config.js](./js/config.js)**: This contains the configuration needed to talk to the backend sever
 
-- **[opentok-api.js](./services/opentok-api.js)**: Configures the **Session ID**, **Token**,
-  and **API Key**, creates the Video API session, and generates tokens for hosts, guests, and
-  viewers. Set the API Key and API Secret in [config.json](./config.json).
+- **[utils.js](./js/utils.js)**: This contains common code used on multiple pages
 
-- **[host.js](./public/js/host.js)**: The host is the individual who controls and publishes
-  the broadcast, but does not control audio or video for guests or viewers. The host uses the
-  Video API [Signaling API](https://www.tokbox.com/developer/guides/signaling/js/) to send the
-  signals to all clients in the session.
+- **[host.js](./js/host.js)**: The host is the individual who controls and publishes
+  the broadcast, but does not control audio or video for viewers.
 
-- **[guest.js](./public/js/guest.js)**: Guests can publish in the broadcast. They can control
-  their own audio and video. The sample app does not include the ability for the host to
-  control whether guests are broadcasting, though the host does have a moderator token that
-  can be used for that purpose.
+- **[view.js](./js/view.js)**: Viewers can view the live WebRTC stream.
 
-- **[viewer.js](./public/js/viewer.js)**: Viewers can view the live WebRTC stream and switch to the Guest and HLS views.
-
-- **[hls-viewer.js](./public/js/hls-viewer.js)**: HLS Viewers can only view the broadcast and switch to the viewer view.
-
-- **[hls-viewer.js](./public/js/hls-viewer.js)**: HLS Viewers can only view the broadcast.
-
-- **[ec.js](./public/js/hls-viewer.js)**: This page defines the code that the Experience Composer instance needs to execute.
-
-- **[CSS files](./public/css)**: Defines the client UI style.
+- **[hls.js](./public/js/hls.js)**: HLS Viewers can only view the broadcast.
 
 ### Server
 
-The methods in [server.js](./server.js) include the host, guest, and viewer routes, as well
-as the broadcast start and end routes. Each of the host, guest, and viewer routes retrieves
-the credentials and creates the token for each user type (moderator, publisher, subscriber)
-defined in [opentok-api.js](./services/opentok-api.js):
+This demo does not contain any of the backend code needed to interact with the Vonage Video REST API. Our
+[Sample Video Node Learning Server](https://github.com/Vonage-Community/sample-video-node-learning_server/) contains all the necessary routes
+to access our REST API.
 
-```javascript
-const tokenOptions = (userType) => {
-  const role = {
-    host: "moderator",
-    guest: "publisher",
-    viewer: "subscriber",
-  }[userType];
+If you are interested, the following routes will be used from the `[routes/index.js](https://github.com/Vonage-Community/sample-video-node-learning_server/blob/main/routes/index.js)` from that project:
 
-  return { role };
-};
-```
+* `/broadcast/:name/host` - This route generates credentials for the broadcast host
+* `/broadcast/:name/viewer` - This route generates credentials for anyone viewing the broadcast via WebRTC
+* `/broadcast/:name/start` - Starts a live broadcast via HLS (Note: Starting a broadcast will end any existing and running broadcasts)
+* `/broadcast/:name/stop` - Stops a live broadcast
 
-The credentials are embedded in an EJS template as JSON. For example, the following host
-route is configured in server.js:
-
-```javascript
-app.get("/host", async (req, res) => {
-  const roomName = req.query.room;
-  try {
-    const credentials = await generateCredentials("host", roomName);
-    res.render("pages/host", {
-      credentials: JSON.stringify(credentials),
-    });
-  } catch (e) {
-    res.status(500).send(error);
-  }
-});
-```
-
-The credentials are then retrieved in [host.js](./public/js/host.js) and used to connect to the host to the session:
-
-```javascript
-  var getCredentials = function () {
-    var el = document.getElementById('credentials');
-    var credentials = JSON.parse(el.getAttribute('data'));
-    el.remove();
-    return credentials;
-  };
-
-  . . .
-
-  var init = function () {
-
-    . . .
-
-    var credentials = getCredentials();
-    var session = OT.initSession(credentials.apiKey, credentials.sessionId);
-    var publisher = initPublisher();
-
-    session.connect(credentials.token, function (error) {
-
-      . . .
-
-    });
-  };
-
-
-```
-
-When the web page is loaded, those credentials are retrieved from the HTML and are used to initialize the session.
-
-The logic needed to start and stop the Experience Composer stream is defined in [opentok-api.js](./services/opentok-api.js) (`createRender` and `deleteRender` respectively). At the time of updating this sample application, the nodeJS SDK does not have support for Experience Composer, so the [REST API](https://www.dev.tokbox.com/developer/rest/#starting_experience_composer) will be used. The `createRender` function creates an Experience Composer instance that will navigate to **[ec.js](./public/js/hls-viewer.js)** and publish a new stream named `EC` into the session.
-
-### Guest
-
-The functions in [guest.js](./public/js/guest.js) retrieve the credentials from the HTML,
-subscribe to the host stream and other guest streams, and publish audio and video to the session.
+When the web page is loaded, those credentials are retrieved from the configured server and used to authenticate the Client SDK to the Vonage Video platform.
 
 ### HLS viewer
 
-The functions in [viewer.js](./public/js/hls-viewer.js) check whether the broadcast is active or not. The HLS viewer can also move to the Viewer view (WebRTC session). Your application is responsible to let the HLS viewers when the HLS stream has started, this could be via WSS or any other way. For simplicity, this sample app has a button that checks the server for the broadcast URL.
-
-**NOTE**: The price for an Experience Composer stream differs from a regular stream. Check [this article](https://video-api.support.vonage.com/hc/en-us/articles/6714156901780-Experience-Composer-Activation-and-Pricing) for further pricing information.
-
-### Experience Composer
-
-The code in [ec.js](./public/js/ec.js) will connect the Experience Composer instance to the session, subscribe to all streams but itself and the screen share stream from the Host and customise the appearance of the page. The result of the interaction with this code, that is, what is visible on this page, will be published as a new stream into the session (see logic on `opentok-api.js`).
+The functions in [hls.js](./js/hls.js) is used to render the HLS stream to the browser. Your application is responsible to let the HLS viewers when the HLS stream has started, this could be via WSS or any other way. 
+For simplicity, this sample app assumes that a broadcast has already started. Once the broadcast is started, the host has a button to open the correct view URL.
 
 ### Viewer
 
-The functions in [viewer.js](./public/js/viewer.js) retrieve the credentials from the HTML,
-connect to the session and subscribe after receiving a signal from the host indicating the broadcast has started, and monitor broadcast status. Once the broadcast begins, the viewer can see the host and guests. Each viewer uses the Video API [Signaling API](https://www.tokbox.com/developer/guides/signaling/js/) to receive the signals sent in the broadcast. The viewer can also move to the HLS viewer view and become a Guest to publish audio and video.
+The functions in [view.js](./js/viewer.js) retrieves the credentials from the the backend server,
+connects to the session and subscribes to the stream in progress.
 
 ### Host
 
-The methods in [host.js](./public/js/host.js) retrieve the credentials from the HTML, set the
-state of the broadcast and update the UI, control the broadcast stream, subscribe to the guest
-streams, create the URL for viewers to watch the broadcast, and signal broadcast status. The
-host UI includes an input field to add an [RTMP stream](https://tokbox.com/developer/beta/rtmp-broadcast/),
-a button to start and end the broadcast, as well as a control to get a sharable link that
-can be distributed to all potential viewers to watch the CDN stream. The host makes calls to
-the server, which calls the Video API API to start and end the broadcast. Once the broadcast ends,
-the client player will recognize an error event and display a message that the broadcast is over.
-For more information, see [Initialize, Connect, and Publish to a Session](https://tokbox.com/developer/concepts/connect-and-publish/).
+The methods in [host.js](./js/host.js) retrieve the credentials from the backend server, control the broadcast stream, and creates
+ the URL for viewers to watch the broadcast. The host makes calls to
+the server, which calls the Vonage Video API to start and end the broadcast. 
+For more information, see [Publishing Streams](https://developer.vonage.com/en/tutorials/publish-streams/introduction/javascript)
+and [Joining a session](https://developer.vonage.com/en/tutorials/joining-a-session/introduction/javascript).
 
-The following method in host.js sets up the publisher session for the host, configures a
-custom UI with controls for the publisher role associated with the host, and sets up event
-listeners for the broadcast button.
-
-```javascript
-var publishAndSubscribe = function (session, publisher) {
-  session.publish(publisher);
-  addPublisherControls(publisher);
-  setEventListeners(session, publisher);
-};
-```
-
-When the broadcast button is clicked, the `startBroadcast()` method is invoked and submits
+When the broadcast button is clicked, the demo submits
 a request to the server endpoint to begin the broadcast. The server endpoint relays the
-session ID to the [Video API HLS Broadcast REST](https://tokbox.com/developer/rest/#start_broadcast)
+session ID to the [Video API HLS Broadcast REST](https://developer.vonage.com/en/api/video#start-broadcast)
 `/broadcast/start` endpoint, which returns broadcast data to the host. The broadcast data
 includes the broadcast URL in its JSON-encoded HTTP response:
 
 ```javascript
-  var startBroadcast = function (session) {
-
-    . . .
-
-    http.post('/broadcast/start', { sessionId: session.sessionId })
-      .then(function (broadcastData) {
-
-        updateStatus(session, 'active');
-
-        . . .
-
-      }
-  };
+document.getElementById('btn-start').addEventListener('click', async (el, event) => {
+    broadcast = await fetch(`${SAMPLE_SERVER_BASE_URL}/broadcast/session/start`, {
+        method: "POST",
+        body: JSON.stringify({
+            rtmp: [],
+            lowLatency: document.getElementById('lowLatency').checked,
+            dvr: document.getElementById('dvr').checked,
+            sessionId: session.id,
+            streamMode: "auto"
+        }),
+        headers: {
+            "Content-type": "application/json"
+        }
+    })
+        .then(res => res.json())
+        .catch(error => console.error(error));
+});
 ```
 
-The `startBroadcast()` method subsequently calls the `updateStatus()` method with the broadcast
-status. The `updateStatus()` method uses the [Video API Signaling API](https://www.tokbox.com/developer/guides/signaling/js/)
-to notify the live viewers who are subscribed to the session that the broadcast has started:
-
-```javascript
-  var updateStatus = function (session, status) {
-
-    . . .
-
-    signal(session, broadcast.status);
-  };
-```
-
-If a guest joins the HLS view after the broadcast has started, it will send a signal to the host to retrieve the current status of the broadcast. If the broadcast is active, the host will send them the URL so they can play the HLS feed.
-
-When the broadcast is over, the `endBroadcast()` method in host.js submits a request to the server,
-which invokes the [Video API Broadcast API](https://tokbox.com/developer/rest/#stop_broadcast) `/broadcast/stop`
+When the broadcast is over, the "End Broadcast" button submits a request to the server,
+which invokes the [Video API Broadcast API](https://developer.vonage.com/en/api/video#stop-broadcast) `/broadcast/stop`
 endpoint, which terminates the CDN stream. This is a recommended best practice, as the default
 is that broadcasts remain active until a 120-minute timeout period has completed.
 
-## Screenshots
-
-### Host View
-
-![Host-view](https://github.com/nexmo-se/broadcast-sample-app/blob/main/public/images/host.jpg?raw=true)
-
-### WebRTC Viewer
-
-![Host-view](https://github.com/nexmo-se/broadcast-sample-app/blob/main/public/images/webrtc.jpg?raw=true)
-
-### HLS Viewer
-
-![Host-view](https://github.com/nexmo-se/broadcast-sample-app/blob/main/public/images/hls.jpg?raw=true)
+```javascript
+document.getElementById('btn-end').addEventListener('click', async (el, event) => {
+  broadcast = await fetch(`${SAMPLE_SERVER_BASE_URL}/broadcast/session/stop`, {
+      method: "POST",
+      body: JSON.stringify({
+          sessionId: session.id
+      }),
+      headers: {
+          "Content-type": "application/json"
+      }
+  })
+      .then(res => res.json())
+      .catch(error => console.error(error));
+});
+```
 
 ## Development and Contributing
 
-Interested in contributing? We :heart: pull requests! See the [Contribution](CONTRIBUTING.md) guidelines.
+Interested in contributing? We :heart: pull requests! See the [Contribution](../CONTRIBUTING.md) guidelines.
 
 ## Getting Help
 
@@ -309,10 +198,10 @@ We love to hear from you so if you have questions, comments or find a bug in the
 know! You can either:
 
 - Open an issue on this repository
-- See <https://support.tokbox.com/> for support options
+- See <https://support.vonage.com/> for support options
 - Tweet at us! We're [@VonageDev](https://twitter.com/VonageDev) on Twitter
 - Or [join the Vonage Developer Community Slack](https://developer.nexmo.com/community/slack)
 
 ## Further Reading
 
-- Check out the Developer Documentation at <https://tokbox.com/developer/>
+- Check out the Developer Documentation at <https://developer.vonage.com/en/video>

--- a/Live-Broadcast/README.md
+++ b/Live-Broadcast/README.md
@@ -162,7 +162,10 @@ document.getElementById('btn-start').addEventListener('click', async (el, event)
             "Content-type": "application/json"
         }
     })
-        .then(res => res.json())
+        .then(res => {
+            session.publish(publisher);
+            return res.json()
+        })
         .catch(error => console.error(error));
 });
 ```
@@ -174,17 +177,21 @@ is that broadcasts remain active until a 120-minute timeout period has completed
 
 ```javascript
 document.getElementById('btn-end').addEventListener('click', async (el, event) => {
-  broadcast = await fetch(`${SAMPLE_SERVER_BASE_URL}/broadcast/session/stop`, {
-      method: "POST",
-      body: JSON.stringify({
-          sessionId: session.id
-      }),
-      headers: {
-          "Content-type": "application/json"
-      }
-  })
-      .then(res => res.json())
-      .catch(error => console.error(error));
+    broadcast = await fetch(`${SAMPLE_SERVER_BASE_URL}/broadcast/session/stop`, {
+        method: "POST",
+        body: JSON.stringify({
+            sessionId: session.id
+        }),
+        headers: {
+            "Content-type": "application/json"
+        }
+    })
+        .then(res => {
+            session.unpublish(publisher);
+            publisher = initPublisher();
+            return res.json()
+        })
+        .catch(error => console.error(error));
 });
 ```
 

--- a/Live-Broadcast/hls.html
+++ b/Live-Broadcast/hls.html
@@ -1,10 +1,9 @@
 <html>
     <head>
-        <title>Broadcast Viewer</title>
+        <title>HLS Viewer</title>
+        <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
         <script src="https://unpkg.com/@vonage/video-client@latest/dist/js/opentok.js"></script>
-        <script src="/js/config.js"></script>
-        <script src="/js/utils.js"></script>
-        <script src="/js/view.js"></script>
+        <script src="/js/hls.js"></script>
 
         <script src="https://cdn.tailwindcss.com"></script>
     </head>
@@ -24,8 +23,10 @@
         </div>
 
         <div class="grid grid-cols-1 container mx-auto pt-4">
-            <h2 class="font-black text-2xl mx-auto">Host Camera</h2>
-            <div class="w-1/2 h-96 mx-auto" id="host"></div>
+            <h2 class="font-black text-2xl mx-auto">HLS Stream</h2>
+            <div id="host">
+                <video class="w-1/2 mx-auto" id="video" autoplay controls></video>
+            </div>
         </div>
     </body>
 </html>

--- a/Live-Broadcast/host.html
+++ b/Live-Broadcast/host.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Vonage Video - Broadcast Viewer</title>
+        <script src="https://unpkg.com/@vonage/video-client@latest/dist/js/opentok.js"></script>
+        <script src="/js/config.js"></script>
+        <script src="/js/utils.js"></script>
+        <script src="/js/host.js"></script>
+
+        <script src="https://cdn.tailwindcss.com"></script>
+    </head>
+
+    <body>
+        <div class="grid grid-cols-3">
+            <div class="h-80 w-80" id="host"></div>
+            <div class="h-80 w-80" id="guest"></div>
+            <div>
+                <button id="btn-start" class="bg-blue-500 bold text-white p-4 rounded">Start Broadcast</button>
+                <button id="btn-end" class="bg-red-500 bold text-white p-4 rounded">Stop Broadcast</button>
+                <button id="btn-view" class="bg-green-500 bold text-white p-4 rounded">View Broadcast</button>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Live-Broadcast/host.html
+++ b/Live-Broadcast/host.html
@@ -36,6 +36,17 @@
             <div x-data="{ broadcastStatus: 'stopped' }">
                 <div class="grid grid-cols-1 gap-4">
                     <div><h2 class="font-black text-2xl">Broadcast Options</h2></div>
+                    <div x-data="{lowLatency: false, dvr: false}">
+                        <div>
+                            <input type="checkbox" id="lowLatency" name="lowLatency" x-bind:disabled="dvr" x-on:click="lowLatency = !lowLatency"> 
+                            <label>Enable Low Latency</label>
+                        </div>
+                        <div>
+                            <input type="checkbox" id="dvr" name="dvr" x-bind:disabled="lowLatency" x-on:click="dvr = !dvr">
+                            <label>Enable DVR</label>
+                        </div>
+                        
+                    </div>
 
                     <div><h2 class="font-black text-2xl">Broadcast Controls</h2></div>
 

--- a/Live-Broadcast/host.html
+++ b/Live-Broadcast/host.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>Vonage Video - Broadcast Viewer</title>
+        <script src="//unpkg.com/alpinejs" defer></script>
         <script src="https://unpkg.com/@vonage/video-client@latest/dist/js/opentok.js"></script>
         <script src="/js/config.js"></script>
         <script src="/js/utils.js"></script>
@@ -11,13 +12,44 @@
     </head>
 
     <body>
-        <div class="grid grid-cols-3">
-            <div class="h-80 w-80" id="host"></div>
-            <div class="h-80 w-80" id="guest"></div>
+        <div class="bg-black flex gap-4">
+            <div class="text-white bold p-4 grow">Live Broadcast Demo</div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/host.html">Host View</a>
+            </div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/hls.html">HLS View</a>
+            </div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/view.html">WebRTC View</a>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-3 container mx-auto pt-4">
             <div>
-                <button id="btn-start" class="bg-blue-500 bold text-white p-4 rounded">Start Broadcast</button>
-                <button id="btn-end" class="bg-red-500 bold text-white p-4 rounded">Stop Broadcast</button>
-                <button id="btn-view" class="bg-green-500 bold text-white p-4 rounded">View Broadcast</button>
+                <h2 class="font-black text-2xl">Your Camera</h2>
+                <div class="h-80 w-80" id="host"></div>
+            </div>
+
+            <div class="h-80 w-80" id="guest"></div>
+
+            <div x-data="{ broadcastStatus: 'stopped' }">
+                <div class="grid grid-cols-1 gap-4">
+                    <div><h2 class="font-black text-2xl">Broadcast Options</h2></div>
+
+                    <div><h2 class="font-black text-2xl">Broadcast Controls</h2></div>
+
+                    <div>
+                        <button x-show="broadcastStatus == 'stopped'" x-on:click="broadcastStatus = 'started'" id="btn-start" class="bg-blue-500 bold text-white p-4 rounded">Start Broadcast</button>
+                        <button x-show="broadcastStatus == 'started'" x-on:click="broadcastStatus = 'stopped'"  id="btn-end" class="bg-red-500 bold text-white p-4 rounded">Stop Broadcast</button>
+                    </div>
+
+                    <div><h2 class="font-black text-2xl">View Controls</h2></div>
+                    <div class="grid gap-4">
+                        <div><button id="btn-view-webrtc" class="bg-green-500 bold text-white p-4 rounded">View Broadcast via WebRTC</button></div>
+                        <div><button x-show="broadcastStatus == 'started'" id="btn-view-hls" class="bg-green-500 bold text-white p-4 rounded">View Broadcast via HLS</button></div>
+                    </div>
+                </div>
             </div>
         </div>
     </body>

--- a/Live-Broadcast/host.html
+++ b/Live-Broadcast/host.html
@@ -36,7 +36,7 @@
             <div x-data="{ broadcastStatus: 'stopped' }">
                 <div class="grid grid-cols-1 gap-4">
                     <div><h2 class="font-black text-2xl">Broadcast Options</h2></div>
-                    <div x-data="{lowLatency: false, dvr: false}">
+                    <div x-data="{lowLatency: false, dvr: false, rtmp: false}">
                         <div>
                             <input type="checkbox" id="lowLatency" name="lowLatency" x-bind:disabled="dvr" x-on:click="lowLatency = !lowLatency"> 
                             <label>Enable Low Latency</label>
@@ -45,7 +45,17 @@
                             <input type="checkbox" id="dvr" name="dvr" x-bind:disabled="lowLatency" x-on:click="dvr = !dvr">
                             <label>Enable DVR</label>
                         </div>
-                        
+                        <div>
+                            <input type="checkbox" id="rtmp" name="rtmp"  x-on:click="rtmp = !rtmp">
+                            <label>Enable RTMP</label>
+                        </div>
+                        <div x-show="rtmp" class="pl-4">
+                            <label for="rtmpAddress">RTMP Address:</label>
+                            <input class="border border-black w-full" type="text" name="rtmpAddress" id="rtmpAddress" />
+
+                            <label for="rtmpAddress">RTMP Key:</label>
+                            <input class="border border-black w-full" type="text" name="rtmpKey" id="rtmpKey" />
+                        </div>
                     </div>
 
                     <div><h2 class="font-black text-2xl">Broadcast Controls</h2></div>
@@ -57,7 +67,7 @@
 
                     <div><h2 class="font-black text-2xl">View Controls</h2></div>
                     <div class="grid gap-4">
-                        <div><button id="btn-view-webrtc" class="bg-green-500 bold text-white p-4 rounded">View Broadcast via WebRTC</button></div>
+                        <div><button x-show="broadcastStatus == 'started'" id="btn-view-webrtc" class="bg-green-500 bold text-white p-4 rounded">View Broadcast via WebRTC</button></div>
                         <div><button x-show="broadcastStatus == 'started'" id="btn-view-hls" class="bg-green-500 bold text-white p-4 rounded">View Broadcast via HLS</button></div>
                     </div>
                 </div>

--- a/Live-Broadcast/index.html
+++ b/Live-Broadcast/index.html
@@ -1,0 +1,36 @@
+<html>
+    <head>
+        <title>Live Broadcast Example</title>
+        <script src="https://cdn.tailwindcss.com"></script>
+    </head>
+
+    <body>
+        <div class="bg-black flex gap-4">
+            <div class="text-white bold p-4 grow">Live Broadcast Demo</div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/host.html">Host View</a>
+            </div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/hls.html">HLS View</a>
+            </div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/view.html">WebRTC View</a>
+            </div>
+        </div>
+
+        <div class="container mx-auto pt-4">
+            <p>This is an interactive demo showing off various Live Broadcasting features of the Vonage Video API.</p>
+
+            <p>Check out the <span class="font-bold">Host View</span> if you want to be the host of a broadcast, and configure wider broadcast settings.</p>
+
+            <p>Check out the <span class="font-bold">WebRTC View</span> if you want to watch a running broadcast and connect using WebRTC.</p>
+
+            <p>Check out the <span class="font-bold">HLS View</span> if you want to watch the broadcast via an HLS Stream.</p>
+
+            <div>
+                <a class="underline text-blue-500" href="/host.html">Host View</a><br />
+                <a class="underline text-blue-500" href="/view.html">View Broadcast via WebRTC</a><br />
+            </div>
+        </div>
+    </body>
+</html>

--- a/Live-Broadcast/js/config.js
+++ b/Live-Broadcast/js/config.js
@@ -1,0 +1,4 @@
+// Set this to the base URL of your sample server, such as 'https://your-app-name.herokuapp.com'.
+// Do not include the trailing slash. See the README for more information:
+
+const SAMPLE_SERVER_BASE_URL = '';

--- a/Live-Broadcast/js/hls.js
+++ b/Live-Broadcast/js/hls.js
@@ -1,0 +1,27 @@
+(() => {
+    document.addEventListener('DOMContentLoaded', () => {
+        const video = document.getElementById('video');
+        const videoSource = new URLSearchParams(window.location.search).get('url');
+
+        if (!videoSource) {
+            alert('No HLS URL was passed. No video will be displayed');
+            return;
+        }
+
+        if (Hls.isSupported()) {
+            const hls = new Hls();
+            hls.on(Hls.Events.MEDIA_ATTACHED, () => {
+                video.muted = true;
+                video.play();
+            });
+
+            hls.loadSource(videoSource);
+            hls.attachMedia(video);
+        } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+            video.src = videoSource;
+        } else {
+            alert('Browser does not seem to have HLS capabilities. No video will be displayed');
+            return;
+        }
+    });
+})();

--- a/Live-Broadcast/js/host.js
+++ b/Live-Broadcast/js/host.js
@@ -69,6 +69,10 @@
             document.getElementById('btn-view-webrtc').addEventListener('click', (el, event) => {
                 window.open('/view.html');
             })
+
+            document.getElementById('btn-view-hls').addEventListener('click', (el, event) => {
+                window.open('/hls.html?url=' + broadcast.broadcastUrls.hls);
+            })
         });
     });
 })();

--- a/Live-Broadcast/js/host.js
+++ b/Live-Broadcast/js/host.js
@@ -39,8 +39,8 @@
                     method: "POST",
                     body: JSON.stringify({
                         rtmp: [],
-                        lowLatency: false,
-                        dvr: false,
+                        lowLatency: document.getElementById('lowLatency').checked,
+                        dvr: document.getElementById('dvr').checked,
                         sessionId: session.id,
                         streamMode: "auto"
                     }),

--- a/Live-Broadcast/js/host.js
+++ b/Live-Broadcast/js/host.js
@@ -1,0 +1,74 @@
+(async () => {
+    let broadcast;
+
+    document.addEventListener('DOMContentLoaded', async () => {
+        const credentials = await getCredentials('host');
+        const session = OT.initSession(
+            credentials.applicationId,
+            credentials.sessionId,
+            {
+                connectEventsSuppressed: true
+            }
+        );
+
+        session.connect(credentials.token, (error) => {
+            if (error) {
+                console.error(error);
+                return;
+            }
+            const publisher = OT.initPublisher('host', {
+                insertMode: 'append',
+                width: '100%',
+                height: '100%',
+            }, (error) => {
+                if (error) { console.log(error); }
+            });
+
+            session.publish(publisher);
+
+            session.on('streamCreated', (event) => {
+                session.subscribe(event.stream, 'guest', {
+                    insertMode: 'append',
+                    width: '100%',
+                    height: '100%',
+                })
+            });
+
+            document.getElementById('btn-start').addEventListener('click', async (el, event) => {
+                broadcast = await fetch(`${SAMPLE_SERVER_BASE_URL}/broadcast/session/start`, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        rtmp: [],
+                        lowLatency: false,
+                        dvr: false,
+                        sessionId: session.id,
+                        streamMode: "auto"
+                    }),
+                    headers: {
+                        "Content-type": "application/json"
+                    }
+                })
+                    .then(res => res.json())
+                    .catch(error => console.error(error));
+            });
+
+            document.getElementById('btn-end').addEventListener('click', async (el, event) => {
+                broadcast = await fetch(`${SAMPLE_SERVER_BASE_URL}/broadcast/session/stop`, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        sessionId: session.id
+                    }),
+                    headers: {
+                        "Content-type": "application/json"
+                    }
+                })
+                    .then(res => res.json())
+                    .catch(error => console.error(error));
+            });
+
+            document.getElementById('btn-view').addEventListener('click', (el, event) => {
+                window.open('/view.html?url=' + broadcast.broadcastUrls.hls)
+            })
+        });
+    });
+})();

--- a/Live-Broadcast/js/host.js
+++ b/Live-Broadcast/js/host.js
@@ -66,8 +66,8 @@
                     .catch(error => console.error(error));
             });
 
-            document.getElementById('btn-view').addEventListener('click', (el, event) => {
-                window.open('/view.html?url=' + broadcast.broadcastUrls.hls)
+            document.getElementById('btn-view-webrtc').addEventListener('click', (el, event) => {
+                window.open('/view.html');
             })
         });
     });

--- a/Live-Broadcast/js/utils.js
+++ b/Live-Broadcast/js/utils.js
@@ -1,0 +1,5 @@
+async function getCredentials(mode) {
+    return await fetch(`${SAMPLE_SERVER_BASE_URL}/broadcast/session/${mode}`)
+            .then(res => res.json())
+            .catch(error => console.error(error));
+}

--- a/Live-Broadcast/js/view.js
+++ b/Live-Broadcast/js/view.js
@@ -1,0 +1,27 @@
+(() => {
+    document.addEventListener('DOMContentLoaded', async () => {
+        const credentials = await getCredentials('viewer');
+        const session = OT.initSession(
+            credentials.applicationId,
+            credentials.sessionId,
+            {
+                connectEventsSuppressed: true
+            }
+        );
+
+        session.connect(credentials.token, (error) => {
+            if (error) {
+                console.log(error);
+                return;
+            }
+
+            session.on('streamCreated', (event) => {
+                session.subscribe(event.stream, 'host', {
+                    insertMode: 'append',
+                    width: '100%',
+                    height: '100%',
+                })
+            });
+        });
+    });
+})();

--- a/Live-Broadcast/package.json
+++ b/Live-Broadcast/package.json
@@ -16,5 +16,11 @@
   "bugs": {
     "url": "https://github.com/vonage-community/video-api-web-samples/issues"
   },
-  "homepage": "https://github.com/vonage-community/video-api-web-samples/Live-Broadcast#readme"
+  "homepage": "https://github.com/vonage-community/video-api-web-samples/Live-Broadcast#readme",
+  "scripts": {
+    "start": "sirv --dev"
+  },
+  "devDependencies": {
+    "sirv-cli": "^2.0.2"
+  }
 }

--- a/Live-Broadcast/package.json
+++ b/Live-Broadcast/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dynamic-video-layouts",
+  "version": "1.0.0",
+  "description": "Vonage Video API Broadcast Sample Application",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vonage-community/video-api-web-samples.git"
+  },
+  "keywords": [
+    "opentok",
+    "broadcast",
+    "webrtc"
+  ],
+  "author": "Chris Tankersley <chris@ctankersley.com>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/vonage-community/video-api-web-samples/issues"
+  },
+  "homepage": "https://github.com/vonage-community/video-api-web-samples/Live-Broadcast#readme"
+}

--- a/Live-Broadcast/view.html
+++ b/Live-Broadcast/view.html
@@ -1,0 +1,15 @@
+<html>
+    <head>
+        <title>Broadcast Viewer</title>
+        <script src="https://unpkg.com/@vonage/video-client@latest/dist/js/opentok.js"></script>
+        <script src="/js/config.js"></script>
+        <script src="/js/utils.js"></script>
+        <script src="/js/view.js"></script>
+    </head>
+
+    <body>
+        <div class="grid grid-cols-3">
+            <div class="h-80 w-80" id="host"></div>
+        </div>
+    </body>
+</html>

--- a/Live-Broadcast/view.html
+++ b/Live-Broadcast/view.html
@@ -5,11 +5,27 @@
         <script src="/js/config.js"></script>
         <script src="/js/utils.js"></script>
         <script src="/js/view.js"></script>
+
+        <script src="https://cdn.tailwindcss.com"></script>
     </head>
 
     <body>
-        <div class="grid grid-cols-3">
-            <div class="h-80 w-80" id="host"></div>
+        <div class="bg-black flex gap-4">
+            <div class="text-white bold p-4 grow">Live Broadcast Demo</div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/host.html">Host View</a>
+            </div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/hls.html">HLS View</a>
+            </div>
+            <div class="text-white bold hover:bg-white hover:text-black p-4">
+                <a href="/view.html">WebRTC View</a>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 container mx-auto pt-4">
+            <h2 class="font-black text-2xl mx-auto">Host Camera</h2>
+            <div class="h-80 w-80 mx-auto" id="host"></div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This is a stripped down version of the full featured Broadcast demo, intended to much easier code reading and slimmed down to show only a few features.

The README and a few docs need cleaned up from the old repo, but would like a first pass of this. This should work with the learning Node.js node server, as one of the goals was to move a lot of that logic to there to keep server stuff in one place, and client stuff in this repo.